### PR TITLE
Rack-attack gem implementation.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,8 @@ gem 'bcrypt', '~> 3.1.7'
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
+# Rack middleware for blocking & throttling abusive requests
+gem 'rack-attack'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,8 @@ GEM
     pg (1.2.2)
     puma (3.12.2)
     rack (2.1.2)
+    rack-attack (6.2.2)
+      rack (>= 1.0, < 3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.4.1)
@@ -171,6 +173,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   puma (~> 3.11)
+  rack-attack
   rails (~> 5.2.4, >= 5.2.4.1)
   rails-controller-testing
   rspec-rails (~> 3.9)
@@ -183,4 +186,4 @@ RUBY VERSION
    ruby 2.4.5p335
 
 BUNDLED WITH
-   1.16.6
+   2.0.2

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Rack
+  class Attack
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+
+    # Allow all local traffic
+    safelist('allow-localhost') do |req|
+      req.ip == '127.0.0.1' || req.ip == '::1'
+    end
+
+    # Allow an IP address to make 10 requests every 2 seconds
+    throttle('req/ip', limit: 10, period: 2, &:ip)
+  end
+end


### PR DESCRIPTION
Add rack-attack gem to protect the application from external abuse (DDNS).

P.S: The standard CORS does not allow any external requests for applications outside of IP 127.0.0.1. May I fix it?